### PR TITLE
Use different class for memes in build desc.

### DIFF
--- a/src/main/java/hudson/plugins/memegen/MemeNotifier.java
+++ b/src/main/java/hudson/plugins/memegen/MemeNotifier.java
@@ -87,7 +87,7 @@ public class MemeNotifier extends Notifier {
 	}
 
 	private void addToBuildDescription(AbstractBuild build, Meme meme) throws IOException {
-			build.setDescription("<img class=\"meme\" src=\"" + meme.getImageURL() + "\" />");
+			build.setDescription("<img class=\"meme-build\" src=\"" + meme.getImageURL() + "\" />");
 	}
 
 	private void addToProjectDescription(AbstractProject proj, Meme meme) throws IOException {


### PR DESCRIPTION
When I enabled the "show in build desc" option the build history box overflowed with memes. It would be nice to put constraint sizes on images and a different class name would help with that.
